### PR TITLE
Update Dockerfile for basix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN adduser --disabled-password \
     ${NB_USER}
 
 # Install python components
-RUN pip3 install git+https://github.com/FEniCS/fiat.git --upgrade && \
+RUN pip3 install git+https://github.com/FEniCS/basix.git --upgrade && \
 	pip3 install git+https://github.com/FEniCS/ufl.git --upgrade && \
 	pip3 install git+https://github.com/FEniCS/ffcx.git --upgrade && \
 	rm -rf /usr/local/include/dolfin /usr/local/include/dolfin.h


### PR DESCRIPTION
I am preparing a lesson on dolfinx (https://gitlab.kitware.com/cmaurini/newfrac-core-numerics) and used and linked your repo. 
I think that you need to update the Dockerfile for basix. I tested on Binder and it seems to work. I hope this suffices. 

Thanks for your excellent work. 