### PR TITLE
Fix: Add link for Finite Element Families

### DIFF
--- a/chapter1/fundamentals_code.ipynb
+++ b/chapter1/fundamentals_code.ipynb
@@ -125,7 +125,7 @@
     "DOLFINx supports a large variety on elements on simplices \n",
     "(triangles and tetrahedra) and non-simplices (quadrilaterals\n",
     "and hexahedra). For an overview, see:\n",
-    "[UFL's element families](https://fenics.readthedocs.io/projects/ufl/en/latest/manual/form_language.html#element-families)\n",
+    "[basix's element families](https://docs.fenicsproject.org/basix/main/python/_autosummary/basix.html#basix.ElementFamily) _Note that Hermite elements are not currently supported._\n",
     "\n",
     "The element degree in the code is 1. This means that we are choosing the standard $P_1$ linear Lagrange element, which has degrees of freedom at the vertices. \n",
     "The computed solution will be continuous across elements and linearly varying in $x$ and $y$ inside each element. Higher degree polynomial approximations are obtained by increasing the degree argument. \n",

--- a/chapter1/fundamentals_code.ipynb
+++ b/chapter1/fundamentals_code.ipynb
@@ -125,7 +125,7 @@
     "DOLFINx supports a large variety on elements on simplices \n",
     "(triangles and tetrahedra) and non-simplices (quadrilaterals\n",
     "and hexahedra). For an overview, see:\n",
-    "*FIXME: Add link to all the elements we support*\n",
+    "[UFL's element families](https://fenics.readthedocs.io/projects/ufl/en/latest/manual/form_language.html#element-families)\n",
     "\n",
     "The element degree in the code is 1. This means that we are choosing the standard $P_1$ linear Lagrange element, which has degrees of freedom at the vertices. \n",
     "The computed solution will be continuous across elements and linearly varying in $x$ and $y$ inside each element. Higher degree polynomial approximations are obtained by increasing the degree argument. \n",

--- a/chapter1/fundamentals_code.ipynb
+++ b/chapter1/fundamentals_code.ipynb
@@ -125,7 +125,7 @@
     "DOLFINx supports a large variety on elements on simplices \n",
     "(triangles and tetrahedra) and non-simplices (quadrilaterals\n",
     "and hexahedra). For an overview, see:\n",
-    "[basix's element families](https://docs.fenicsproject.org/basix/main/python/_autosummary/basix.html#basix.ElementFamily) _Note that Hermite elements are not currently supported._\n",
+    "[Basix's element families](https://docs.fenicsproject.org/basix/main/python/_autosummary/basix.html#basix.ElementFamily) _Note that Hermite elements are not currently supported in FFCx and DOLFINx._\n",
     "\n",
     "The element degree in the code is 1. This means that we are choosing the standard $P_1$ linear Lagrange element, which has degrees of freedom at the vertices. \n",
     "The computed solution will be continuous across elements and linearly varying in $x$ and $y$ inside each element. Higher degree polynomial approximations are obtained by increasing the degree argument. \n",


### PR DESCRIPTION
Addresses FIXME comment in current documentation

(Not sure if this is the only file that needs to be edited for this change, but at least from looking at the website it _seemed_ like this was the right spot to edit)