### PR TITLE
Hack to launch jupyter-server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Don't include the .git in the image. It's big!
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ ARG NB_UID=1000
 RUN useradd -m ${NB_USER} -u ${NB_UID}
 ENV HOME /home/${NB_USER}
 
+# for binder: base image upgrades lab to require jupyter-server 2,
+# but binder explicitly launches jupyter-notebook
+# force binder to launch jupyter-server instead
+RUN nb=$(which jupyter-notebook) \
+ && rm $nb \
+ && ln -s $(which jupyter-lab) $nb
+
 # Copy home directory for usage in binder
 WORKDIR ${HOME}
 COPY --chown=${NB_UID} . ${HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM ghcr.io/jorgensd/dolfinx-tutorial:v0.6.0
 
 # create user with a home directory
-ARG NB_USER
+ARG NB_USER=jovyan
 ARG NB_UID=1000
-ENV USER ${NB_USER}
+RUN useradd -m ${NB_USER} -u ${NB_UID}
 ENV HOME /home/${NB_USER}
 
 # Copy home directory for usage in binder
 WORKDIR ${HOME}
-COPY . ${HOME}
-USER root
-RUN chown -R ${NB_UID} ${HOME}
+COPY --chown=${NB_UID} . ${HOME}
 
 USER ${NB_USER}
 ENTRYPOINT []


### PR DESCRIPTION
Reduces image size by hundreds of MB by:

- excluding .git
- `COPY --chown` instead of two-step `COPY/RUN chown` which doubles size in image

Hacks a fix for too-new jupyterlab, jupyter-server and friends by replacing `jupyter-notebook` with `jupyer-lab`. This is really a problem BinderHub/repo2docker need to fix.