### PR TITLE
Fix typo in linearelasticity

### DIFF
--- a/chapter2/linearelasticity_code.ipynb
+++ b/chapter2/linearelasticity_code.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "source": [
     "## Boundary conditions\n",
-    "As we would like to clamp the boundary at $x=0$, we do this by using a marker function, which locate the facets where $x$ is close to zero by machine prescision."
+    "As we would like to clamp the boundary at $x=0$, we do this by using a marker function, which locate the facets where $x$ is close to zero by machine precision."
    ]
   },
   {

--- a/chapter2/linearelasticity_code.py
+++ b/chapter2/linearelasticity_code.py
@@ -51,7 +51,7 @@ V = fem.VectorFunctionSpace(domain, ("Lagrange", 1))
 
 
 # ## Boundary conditions
-# As we would like to clamp the boundary at $x=0$, we do this by using a marker function, which locate the facets where $x$ is close to zero by machine prescision.
+# As we would like to clamp the boundary at $x=0$, we do this by using a marker function, which locate the facets where $x$ is close to zero by machine precision.
 
 # +
 def clamped_boundary(x):


### PR DESCRIPTION
The word *precision* was incorrectly written.