### PR TITLE
small typo in membrane_code.ipynb

### DIFF
--- a/chapter1/membrane_code.ipynb
+++ b/chapter1/membrane_code.ipynb
@@ -338,7 +338,7 @@
    "metadata": {},
    "source": [
     "Now we can compute which cells the bounding box tree collides with using `dolfinx.geometry.compute_collisions_points`. This function returns a list of cells whose bounding box collide for each input point. As different points might have different number of cells, the data is stored in `dolfinx.cpp.graph.AdjacencyList_int32`, where one can access the cells for the `i`th point by calling `links(i)`.\n",
-    "However, as the bounding box of a cell spans more of $\\mathbb{R}^n$ than the actual cell, we check that the actual cell collides with cell\n",
+    "However, as the bounding box of a cell spans more of $\\mathbb{R}^n$ than the actual cell, we check that the actual cell collides with the input point\n",
     "using `dolfinx.geometry.select_colliding_cells`, which measures the exact distance between the point and the cell (approximated as a convex hull for higher order geometries).\n",
     "This function also returns an adjacency-list, as the point might align with a facet, edge or vertex that is shared between multiple cells in the mesh.\n",
     "\n",

--- a/chapter1/membrane_code.py
+++ b/chapter1/membrane_code.py
@@ -171,7 +171,7 @@ from dolfinx import geometry
 bb_tree = geometry.bb_tree(domain, domain.topology.dim)
 
 # Now we can compute which cells the bounding box tree collides with using `dolfinx.geometry.compute_collisions_points`. This function returns a list of cells whose bounding box collide for each input point. As different points might have different number of cells, the data is stored in `dolfinx.cpp.graph.AdjacencyList_int32`, where one can access the cells for the `i`th point by calling `links(i)`.
-# However, as the bounding box of a cell spans more of $\mathbb{R}^n$ than the actual cell, we check that the actual cell collides with cell
+# However, as the bounding box of a cell spans more of $\mathbb{R}^n$ than the actual cell, we check that the actual cell collides with the input point
 # using `dolfinx.geometry.select_colliding_cells`, which measures the exact distance between the point and the cell (approximated as a convex hull for higher order geometries).
 # This function also returns an adjacency-list, as the point might align with a facet, edge or vertex that is shared between multiple cells in the mesh.
 #


### PR DESCRIPTION
There was an small typo in membrane_code.ipynb. I modified it and run pytext sync. I hope now Is ok (I don't know if I did it ok)