### PR TITLE
dolfinx.fem.Form changed to dolfinx.fem.form

### DIFF
--- a/chapter1/complex_mode.py
+++ b/chapter1/complex_mode.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (DOLFINx complex)
 #     language: python

--- a/chapter1/fundamentals_code.py
+++ b/chapter1/fundamentals_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter1/membrane_code.py
+++ b/chapter1/membrane_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter1/nitsche.py
+++ b/chapter1/nitsche.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/diffusion_code.ipynb
+++ b/chapter2/diffusion_code.ipynb
@@ -24,6 +24,7 @@
    "outputs": [],
    "source": [
     "import matplotlib as mpl\n",
+    "import matplotlib.pyplot as plt\n",
     "import pyvista\n",
     "import ufl\n",
     "import numpy as np\n",

--- a/chapter2/diffusion_code.py
+++ b/chapter2/diffusion_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/heat_code.py
+++ b/chapter2/heat_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/hyperelasticity.py
+++ b/chapter2/hyperelasticity.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/linearelasticity_code.py
+++ b/chapter2/linearelasticity_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/nonlinpoisson_code.py
+++ b/chapter2/nonlinpoisson_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/ns_code1.py
+++ b/chapter2/ns_code1.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter2/ns_code2.py
+++ b/chapter2/ns_code2.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/component_bc.py
+++ b/chapter3/component_bc.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/em.py
+++ b/chapter3/em.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/multiple_dirichlet.py
+++ b/chapter3/multiple_dirichlet.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/neumann_dirichlet_code.py
+++ b/chapter3/neumann_dirichlet_code.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/robin_neumann_dirichlet.py
+++ b/chapter3/robin_neumann_dirichlet.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter3/subdomains.py
+++ b/chapter3/subdomains.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter4/compiler_parameters.ipynb
+++ b/chapter4/compiler_parameters.ipynb
@@ -58,7 +58,7 @@
    "id": "3f832e78",
    "metadata": {},
    "source": [
-    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.Form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument."
+    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument."
    ]
   },
   {

--- a/chapter4/compiler_parameters.ipynb
+++ b/chapter4/compiler_parameters.ipynb
@@ -58,7 +58,7 @@
    "id": "3f832e78",
    "metadata": {},
    "source": [
-    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.Form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument."
+    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.form` to compile the variational form. For codes using `dolfinx.fem.petsc.LinearProblem`, you can supply `jit_options` as a keyword argument."
    ]
   },
   {

--- a/chapter4/compiler_parameters.ipynb
+++ b/chapter4/compiler_parameters.ipynb
@@ -58,7 +58,7 @@
    "id": "3f832e78",
    "metadata": {},
    "source": [
-    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument."
+    "Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.Form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument."
    ]
   },
   {

--- a/chapter4/compiler_parameters.py
+++ b/chapter4/compiler_parameters.py
@@ -46,7 +46,7 @@ cache_dir = f"{str(Path.cwd())}/.cache"
 print(f"Directory to put C files in: {cache_dir}")
 # -
 
-# Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.Form` to compile the variational form. For codes using `dolfinx.LinearProblem`, you can supply `jit_options` as a keyword argument.
+# Next we generate a general function to assemble the mass matrix for a unit cube. Note that we use `dolfinx.fem.form` to compile the variational form. For codes using `dolfinx.fem.petsc.LinearProblem`, you can supply `jit_options` as a keyword argument.
 
 # +
 

--- a/chapter4/compiler_parameters.py
+++ b/chapter4/compiler_parameters.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter4/convergence.py
+++ b/chapter4/convergence.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter4/newton-solver.py
+++ b/chapter4/newton-solver.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python

--- a/chapter4/solvers.py
+++ b/chapter4/solvers.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.16.1
+#       jupytext_version: 1.16.4
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python


### PR DESCRIPTION
In the chapter about JIT compiler options in the text was said that the form was compiled using `dolfinx.fem.Form` instead of `dolfinx.fem.form` as was done in the code cell. 

jupytext sync was ran