### PR TITLE
update for latest binder/base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,9 @@ FROM ghcr.io/jorgensd/dolfinx-tutorial:release
 # create user with a home directory
 ARG NB_USER=jovyan
 ARG NB_UID=1000
-RUN useradd -m ${NB_USER} -u ${NB_UID}
-ENV HOME /home/${NB_USER}
-
-# for binder: base image upgrades lab to require jupyter-server 2,
-# but binder explicitly launches jupyter-notebook
-# force binder to launch jupyter-server instead
-RUN nb=$(which jupyter-notebook) \
-    && rm $nb \
-    && ln -s $(which jupyter-lab) $nb
+# 24.04 adds uid 1000, skip this if uid already exists
+RUN useradd -m ${NB_USER} -u ${NB_UID} || true
+ENV HOME=/home/${NB_USER}
 
 # Copy home directory for usage in binder
 WORKDIR ${HOME}


### PR DESCRIPTION
- remove workaround for incompatible notebook/lab fixed in repo2docker
- allow for adduser to be redundant if uid already exists