### PR TITLE
remove previous user before creating new one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,10 @@ FROM ghcr.io/jorgensd/dolfinx-tutorial:release
 # create user with a home directory
 ARG NB_USER=jovyan
 ARG NB_UID=1000
-# 24.04 adds uid 1000, skip this if uid already exists
-RUN useradd -m ${NB_USER} -u ${NB_UID} || true
+# 24.04 adds `ubuntu` as uid 1000;
+# remove it if it already exists before creating our user
+RUN id -nu ${NB_UID} && userdel --force $(id -nu ${NB_UID}) || true; \
+    useradd -m ${NB_USER} -u ${NB_UID}
 ENV HOME=/home/${NB_USER}
 
 # Copy home directory for usage in binder


### PR DESCRIPTION
avoids issues with default home dir being owned by root